### PR TITLE
Add SSN rule and Luhn validation for credit card PII

### DIFF
--- a/src/qarai_agent_guard/core/detectors/PIIDetector.py
+++ b/src/qarai_agent_guard/core/detectors/PIIDetector.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import Any
 
 from qarai_agent_guard.core.detectors.BaseDetector import BaseDetector
+from qarai_agent_guard.core.helpers.stringify import _stringify
 from qarai_agent_guard.core.loaders.pattern_loader import PatternLoader
-from qarai_agent_guard.core.schemas.detection import PATTERNS_ROOT
+from qarai_agent_guard.core.schemas.detection import PATTERNS_ROOT, DetectionResult, Match
 
 
 class PIIDetector(BaseDetector):
@@ -88,3 +89,111 @@ class PIIDetector(BaseDetector):
         return self._loader.load_patterns(
             PATTERNS_ROOT / "common" / "pii.yaml",
         )
+
+    @staticmethod
+    def _is_luhn_valid(candidate: str) -> bool:
+        """Return whether a candidate card number passes Luhn checksum."""
+        digits = "".join(ch for ch in candidate if ch.isdigit())
+        if len(digits) < 13 or len(digits) > 19:
+            return False
+
+        total = 0
+        parity = len(digits) % 2
+        for index, char in enumerate(digits):
+            digit = int(char)
+            if index % 2 == parity:
+                digit *= 2
+                if digit > 9:
+                    digit -= 9
+            total += digit
+        return total % 10 == 0
+
+    def inspect(
+        self,
+        key: str,
+        value: Any,
+        *,
+        operation: str,
+    ) -> DetectionResult:
+        """Scan payload and apply Luhn filtering to credit card candidates."""
+        if not isinstance(key, str):
+            msg = f"key must be str, got {type(key).__name__}"
+            raise TypeError(msg)
+        if not key.strip():
+            msg = "key must not be empty"
+            raise ValueError(msg)
+        if not isinstance(operation, str):
+            msg = f"operation must be str, got {type(operation).__name__}"
+            raise TypeError(msg)
+        if not operation.strip():
+            msg = "operation must not be empty"
+            raise ValueError(msg)
+
+        text = _stringify(value)
+        if not text:
+            return DetectionResult(detector=self.name, matched=False)
+
+        hits: list[Match] = []
+        for index, pattern in enumerate(self._compiled):
+            rule = self._rules[index]
+
+            if rule["id"] == "credit_card":
+                candidate = next(
+                    (
+                        match.group(0)
+                        for match in pattern.finditer(text)
+                        if self._is_luhn_valid(match.group(0))
+                    ),
+                    None,
+                )
+                if candidate is None:
+                    continue
+                hit = candidate
+            else:
+                match = pattern.search(text)
+                if not match:
+                    continue
+                hit = match.group(0)
+
+            hits.append(
+                Match(
+                    pattern_id=rule["id"],
+                    pattern_name=rule["name"],
+                    severity=rule["severity"],
+                    match=hit,
+                )
+            )
+
+        if not hits:
+            return DetectionResult(detector=self.name, matched=False)
+
+        return DetectionResult(
+            detector=self.name,
+            matched=True,
+            matches=hits,
+            message=f"{self.default_message} in '{key}'",
+            metadata={
+                "language": self._lang,
+                "hit_count": len(hits),
+                "operation": operation,
+            },
+        )
+
+    def redact(self, value: Any) -> Any:
+        """Redact only Luhn-valid credit cards; keep invalid numeric strings."""
+        credit_card_redaction = "[REDACTED:credit_card]"
+        original = _stringify(value)
+        for index, pattern in enumerate(self._compiled):
+            rule = self._rules[index]
+            if rule["id"] == "credit_card":
+                original = pattern.sub(
+                    lambda m: (
+                        credit_card_redaction
+                        if self._is_luhn_valid(m.group(0))
+                        else m.group(0)
+                    ),
+                    original,
+                )
+            else:
+                original = pattern.sub(f"[REDACTED:{rule['id']}]", original)
+        return original

--- a/src/qarai_agent_guard/core/detectors/patterns/common/pii.yaml
+++ b/src/qarai_agent_guard/core/detectors/patterns/common/pii.yaml
@@ -9,6 +9,10 @@ rules:
     name: IBAN
     severity: medium
     pattern: '\b[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}\b'
+  - id: ssn_us
+    name: SSN (US)
+    severity: critical
+    pattern: '\b\d{3}-\d{2}-\d{4}\b'
   - id: email
     name: Email
     severity: low

--- a/tests/test_pii_detector.py
+++ b/tests/test_pii_detector.py
@@ -15,6 +15,38 @@ def test_detects_credit_card():
     assert result.matches[0].severity == "critical"
 
 
+def test_detects_us_ssn():
+    detector = PIIDetector()
+    result = detector.inspect(
+        key="memory",
+        value="my ssn is 123-45-6789",
+        operation="write",
+    )
+    assert result.matched is True
+    assert any(match.pattern_id == "ssn_us" for match in result.matches)
+
+
+def test_invalid_credit_card_is_not_detected():
+    detector = PIIDetector()
+    result = detector.inspect(
+        key="memory",
+        value="order id 4111 1111 1111 1112",
+        operation="write",
+    )
+    assert result.matched is False
+
+
+def test_detects_valid_card_after_invalid_candidate():
+    detector = PIIDetector()
+    result = detector.inspect(
+        key="memory",
+        value="ids 4111 1111 1111 1112 and 4111 1111 1111 1111",
+        operation="write",
+    )
+    assert result.matched is True
+    assert any(match.pattern_id == "credit_card" for match in result.matches)
+
+
 def test_ignore_email():
     detector = PIIDetector(ignore=frozenset({"email"}))
     result = detector.inspect(
@@ -29,6 +61,13 @@ def test_redact_masks_matches():
     detector = PIIDetector()
     redacted = detector.redact("card 4111 1111 1111 1111")
     assert "[REDACTED:credit_card]" in redacted
+
+
+def test_redact_keeps_invalid_credit_card_like_numbers():
+    detector = PIIDetector()
+    redacted = detector.redact("order id 4111 1111 1111 1112")
+    assert "[REDACTED:credit_card]" not in redacted
+    assert "4111 1111 1111 1112" in redacted
 
 
 def test_pii_detector_loads_pattern_paths():


### PR DESCRIPTION
## Overview
This PR fixes two PII-detection correctness issues in the core package:
1. Adds missing US SSN detection so behavior matches documented quickstart expectations.
2. Reduces credit-card false positives by validating regex matches with a Luhn checksum before detection/redaction.

## Related Issue
Fixes #4 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD changes
- [x] Test changes
- [ ] Framework / integration (e.g. LangChain, new sub-package)
- [ ] Other:

## Changes Made
- Added ssn_us rule to PII patterns with US SSN format matching.
- Updated PIIDetector inspect logic to accept credit_card matches only when Luhn-valid.
- Updated PIIDetector redaction logic so invalid 13-19 digit strings are not redacted as credit cards.
- Added/updated tests covering SSN detection, invalid-card rejection, mixed invalid+valid candidate handling, and redaction behavior.

## Affected Packages
- [x] qarai-agent-guard (core)
- [ ] qarai-agent-guard-langchain


## Testing
- [ ] pytest passes locally
- [x] Added or updated tests for the change
- [x] Tested manually (describe below if applicable)
- [ ] If docs changed, links and code samples render correctly

Manual/targeted validation:
- Ran pytest against the PII test module with PYTHONPATH=src.
- Result: all tests in that module passed, including newly added coverage.

## Breaking Changes
None.

## Checklist
- [x] Code follows the project style
- [x] No unverifiable claims added to README or docs
- [x] Documentation updated if needed
- [x] No unnecessary/unrelated changes included
- [ ] CI passes

## Additional Notes
This is intentionally scoped to issue #4 only.
Potential follow-up: regional/non-US identity patterns could be added in a separate issue/PR to keep review focused.
